### PR TITLE
Fix ray casting with horizontal edges

### DIFF
--- a/src/main/java/java_report/demo/Circle.java
+++ b/src/main/java/java_report/demo/Circle.java
@@ -73,6 +73,11 @@ public class Circle extends Shape {
             Point tmp = a; a = b; b = tmp;
         }
 
+        // 수평선분은 교차하지 않음
+        if (Math.abs(a.getY() - b.getY()) < 1e-12) {
+            return false;
+        }
+
         if (p.getY() == a.getY() || p.getY() == b.getY()) {
             p = new Point(p.getX(), p.getY() + 1e-10);
         }

--- a/src/main/java/java_report/demo/RegularPolygon.java
+++ b/src/main/java/java_report/demo/RegularPolygon.java
@@ -115,6 +115,11 @@ public class RegularPolygon extends Shape {
             Point tmp = a; a = b; b = tmp;
         }
 
+        // 수평선분은 교차하지 않음
+        if (Math.abs(a.getY() - b.getY()) < 1e-12) {
+            return false;
+        }
+
         if (p.getY() == a.getY() || p.getY() == b.getY()) {
             p = new Point(p.getX(), p.getY() + 1e-10);
         }


### PR DESCRIPTION
## Summary
- handle horizontal segments correctly when checking ray intersections for point-in-polygon tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_683fd174bd90832787f625b9fbb7ff22